### PR TITLE
[Fixes AB#714] Popup cancel button fix

### DIFF
--- a/src/styles/overrides/_swal-overrides.scss
+++ b/src/styles/overrides/_swal-overrides.scss
@@ -2,8 +2,11 @@
 @import "fonts";
 
 @mixin popup-buttton-color($color) {
-  button {
+  button.swal2-confirm {
     background-color: $color !important;
+  }
+  button.swal2-cancel {
+    background-color: $primary-color !important;
   }
 }
 
@@ -43,15 +46,20 @@
     margin: 65px 0 0 0 !important;
     width: 100%;
   }
-  
+
   button {
     width: 100%;
     height: 64px;
-    margin: 0 !important;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
     border-radius: 2px;
     &:focus {
       box-shadow: unset !important;
     }
+  }
+
+  button.swal2-cancel {
+    margin-top: 20px
   }
 }
 


### PR DESCRIPTION
Cancel button now uses primary app color as a background color.

Added margin to separate buttons.